### PR TITLE
Added view to show location summary via the mode GET parameter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,7 @@ function App() {
   const [finishedRealExamples, setFinishedRealExamples] = useState([]);
   const [animationFrame, setAnimationFrame] = useState(1);
   const [attempts, setAttempts] = useState([]);
+  const [attemptsLoaded, setAttemptsLoaded] = useState(false);
 
   useEffect(() => {
     if (!END_PLATE_STATES.includes(plateState))
@@ -64,6 +65,7 @@ function App() {
 
   function loadLatestStateFromWISE(state) {
     setAttempts(state.studentData.attempts);
+    setAttemptsLoaded(true);
     const finishedRealExamples = [];
     for (const attempt of state.studentData.attempts) {
       if (attempt.isCorrect) {
@@ -212,22 +214,46 @@ function App() {
     return urlParams.has('mode') && urlParams.get('mode') === 'showLocationSummary';
   }
 
-  function getLocationParam() {
+  function getParam(param) {
     const urlParams = new URLSearchParams(window.location.search);
-    return urlParams.get('location');
+    return urlParams.get(param);
   }
 
   function showLocationSummary() {
-    const location = getLocationParam();
-    const attemptsForLocation = attempts.filter((attempt) => {
-      return attempt.selectedExample === location;
-    });
-    if (attemptsForLocation.length > 0) {
-      const lastAttempt = attemptsForLocation[attemptsForLocation.length - 1];
-      return <LocationSummary attempt={lastAttempt} location={location} />;
-    } else {
+    if (!attemptsLoaded) {
       return null;
     }
+    const location = getParam('location');
+    const attemptsForLocation = getAttemptsForLocation(location);
+    let lastAttempt = null;
+    if (attemptsForLocation.length > 0) {
+      lastAttempt = attemptsForLocation[attemptsForLocation.length - 1];
+    }
+    return showLocationAttempt(lastAttempt, location);
+  }
+
+  function getAttemptsForLocation(location) {
+    let locationAttempts = [];
+    if (attempts) {
+      locationAttempts = attempts.filter((attempt) => {
+        return attempt.selectedExample === location;
+      });
+    }
+    return locationAttempts;
+  }
+
+  function showLocationAttempt(lastAttempt, location) {
+    const showLocationText = getParam('showLocationText') === 'false' ? false : true;
+    const showBoundarySelection = getParam('showBoundarySelection') === 'false' ? false : true;
+    const showStudentText = getParam('showStudentText') === 'false' ? false : true;
+    return (
+      <LocationSummary 
+        attempt={lastAttempt}
+        location={location}
+        showLocationText={showLocationText}
+        showBoundarySelection={showBoundarySelection}
+        showStudentText={showStudentText} />
+    );
   }
 
   function showDefaultMode() {

--- a/src/App.js
+++ b/src/App.js
@@ -243,9 +243,9 @@ function App() {
   }
 
   function showLocationAttempt(lastAttempt, location) {
-    const showLocationText = getParam('showLocationText') === 'false' ? false : true;
-    const showBoundarySelection = getParam('showBoundarySelection') === 'false' ? false : true;
-    const showStudentText = getParam('showStudentText') === 'false' ? false : true;
+    const showLocationText = getParam('showLocationText') !== 'false';
+    const showBoundarySelection = getParam('showBoundarySelection') !== 'false';
+    const showStudentText = getParam('showStudentText') !== 'false';
     return (
       <LocationSummary 
         attempt={lastAttempt}

--- a/src/components/LocationSummary.css
+++ b/src/components/LocationSummary.css
@@ -23,9 +23,17 @@
 
 .attempt.no-data {
   font-weight: 500;
-  color: #c62828;
+  color: #C62828;
   text-align: center;
-  border-color: #c62828;
+  border-color: #C62828;
   max-width: 700px;
   margin: 0 auto;
+}
+
+.correct {
+  color: #00C853;
+}
+
+.incorrect {
+  color: #C62828;
 }

--- a/src/components/LocationSummary.css
+++ b/src/components/LocationSummary.css
@@ -1,0 +1,31 @@
+.Location {
+  font-size: 16px;
+  color: #333333;
+  font-family: Roboto, 'Helvetica Nueue', sans-serif;
+}
+
+.attempt {
+  padding: .5em;
+  border-radius: 6px;
+  border: 2px solid #1565C0;
+}
+
+.attempt h4 {
+  margin: 0 0 .25em;
+  font-size: 1.25em;
+  font-weight: 400;
+  color: #1565C0;
+}
+
+.attempt p {
+  margin: .25em 0;
+}
+
+.attempt.no-data {
+  font-weight: 500;
+  color: #c62828;
+  text-align: center;
+  border-color: #c62828;
+  max-width: 700px;
+  margin: 0 auto;
+}

--- a/src/components/LocationSummary.js
+++ b/src/components/LocationSummary.js
@@ -1,13 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './LocationSummary.css';
 
 LocationSummary.propTypes = {
   attempt: PropTypes.object,
-  location: PropTypes.string
+  location: PropTypes.string,
+  showLocationText: PropTypes.bool,
+  showBoundarySelection: PropTypes.bool,
+  showStudentText: PropTypes.bool
 };
 
 function LocationSummary(props) {
-  return <p>{props.attempt.studentText}</p>;
+  const endStateToText = {
+    'ccc': 'Continental-Continental, Convergent',
+    'ccd': 'Continental-Continental, Divergent',
+    'coc': 'Continental-Oceanic, Convergent',
+    'ooc': 'Oceanic-Oceanic, Convergent',
+    'ood': 'Oceanic-Oceanic, Divergent'
+  };
+
+  function getLocationText() {
+    if (props.showLocationText) {
+      return (
+        <h4>{props.attempt.selectedExampleText}</h4>
+      );
+    }
+  }
+
+  function getBoundarySelection() {
+    if (props.showBoundarySelection) {
+      return (
+        <p><strong>Predicted Boundary Type:</strong> {endStateToText[props.attempt.endState]}</p>
+      );
+    }
+  }
+
+  function getStudentText() {
+    if (props.showStudentText) {
+      return (
+        <p><strong>Explanation:</strong> "{props.attempt.studentText}"</p>
+      );
+    }
+  }
+  return (
+    <div className="Location">
+      {(() => { 
+        if (props.attempt) {
+          return (
+            <div className="attempt">
+              { getLocationText() }
+              { getBoundarySelection() }
+              { getStudentText() }
+            </div>
+          );
+        } else {
+          return (
+            <div className="attempt no-data">You haven't explored this landmark. Please go back to the model to enter a prediction.</div>
+          );
+        }
+      })()}
+    </div>
+  );
 }
 
 export default LocationSummary;

--- a/src/components/LocationSummary.js
+++ b/src/components/LocationSummary.js
@@ -29,8 +29,11 @@ function LocationSummary(props) {
 
   function getBoundarySelection() {
     if (props.showBoundarySelection) {
+      const isCorrectHtml = props.attempt.isCorrect ? 
+          <span class="correct">(Correct)</span> :
+          <span class="incorrect">(Incorrect)</span>;
       return (
-        <p><strong>Predicted Boundary Type:</strong> {endStateToText[props.attempt.endState]}</p>
+        <p><strong>Predicted Boundary Type:</strong> {endStateToText[props.attempt.endState]} {isCorrectHtml}</p>
       );
     }
   }

--- a/src/components/LocationSummary.js
+++ b/src/components/LocationSummary.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+LocationSummary.propTypes = {
+  attempt: PropTypes.object,
+  location: PropTypes.string
+};
+
+function LocationSummary(props) {
+  return <p>{props.attempt.studentText}</p>;
+}
+
+export default LocationSummary;

--- a/src/components/LocationSummary.js
+++ b/src/components/LocationSummary.js
@@ -15,6 +15,7 @@ function LocationSummary(props) {
     'ccc': 'Continental-Continental, Convergent',
     'ccd': 'Continental-Continental, Divergent',
     'coc': 'Continental-Oceanic, Convergent',
+    'cod': 'Continental-Oceanic, Divergent',
     'ooc': 'Oceanic-Oceanic, Convergent',
     'ood': 'Oceanic-Oceanic, Divergent'
   };


### PR DESCRIPTION
**Description**
I added a location summary view for this model that can be shown by passing in a mode=showLocationSummary GET parameter. The location can be specified by an additional location=[ccd/ooc/ood/cod/coc] GET param. Right now the view only shows what you typed in the prediction textarea.

**Testing**
1. Create an embedded component and set its url to 
```
pt-boundary-explorer/index.html
```

2. In another step, create another embedded component, connect it to the first PT model component using "connected components", and set its url to
```
pt-boundary-explorer/index.html?mode=showLocationSummary&location=ccd
```

3. As a student, do work on location ccd in the first embedded component. Remember what you wrote in the prediction textarea.
4. Go to the second embedded component. It should display what you wrote in the previous step.

Closes #1 